### PR TITLE
Jackson support

### DIFF
--- a/ktor-core/src/org/jetbrains/ktor/testing/Utils.kt
+++ b/ktor-core/src/org/jetbrains/ktor/testing/Utils.kt
@@ -1,8 +1,7 @@
-package org.jetbrains.ktor.tests
+package org.jetbrains.ktor.testing
 
 import com.typesafe.config.*
 import org.jetbrains.ktor.application.*
-import org.jetbrains.ktor.testing.*
 
 object On
 

--- a/ktor-core/test/org/jetbrains/ktor/tests/application/ApplicationRequestHeaderTest.kt
+++ b/ktor-core/test/org/jetbrains/ktor/tests/application/ApplicationRequestHeaderTest.kt
@@ -3,7 +3,7 @@ package org.jetbrains.ktor.tests.application
 import org.jetbrains.ktor.application.*
 import org.jetbrains.ktor.http.*
 import org.jetbrains.ktor.routing.*
-import org.jetbrains.ktor.tests.*
+import org.jetbrains.ktor.testing.*
 import org.junit.*
 import kotlin.test.*
 

--- a/ktor-core/test/org/jetbrains/ktor/tests/application/HandlerTest.kt
+++ b/ktor-core/test/org/jetbrains/ktor/tests/application/HandlerTest.kt
@@ -2,7 +2,7 @@ package org.jetbrains.ktor.tests.application
 
 import org.jetbrains.ktor.application.*
 import org.jetbrains.ktor.http.*
-import org.jetbrains.ktor.tests.*
+import org.jetbrains.ktor.testing.*
 import org.junit.*
 import kotlin.test.*
 

--- a/ktor-core/test/org/jetbrains/ktor/tests/auth/AuthBuildersTest.kt
+++ b/ktor-core/test/org/jetbrains/ktor/tests/auth/AuthBuildersTest.kt
@@ -2,7 +2,7 @@ package org.jetbrains.ktor.tests.auth
 
 import org.jetbrains.ktor.auth.*
 import org.jetbrains.ktor.routing.*
-import org.jetbrains.ktor.tests.*
+import org.jetbrains.ktor.testing.*
 import org.junit.*
 import kotlin.test.*
 

--- a/ktor-core/test/org/jetbrains/ktor/tests/auth/DigestTest.kt
+++ b/ktor-core/test/org/jetbrains/ktor/tests/auth/DigestTest.kt
@@ -4,7 +4,7 @@ import org.jetbrains.ktor.application.*
 import org.jetbrains.ktor.auth.*
 import org.jetbrains.ktor.http.*
 import org.jetbrains.ktor.routing.*
-import org.jetbrains.ktor.tests.*
+import org.jetbrains.ktor.testing.*
 import org.junit.*
 import java.security.*
 import kotlin.test.*

--- a/ktor-core/test/org/jetbrains/ktor/tests/http/ContentTypeTest.kt
+++ b/ktor-core/test/org/jetbrains/ktor/tests/http/ContentTypeTest.kt
@@ -1,7 +1,7 @@
 package org.jetbrains.ktor.tests.http
 
 import org.jetbrains.ktor.http.*
-import org.jetbrains.ktor.tests.*
+import org.jetbrains.ktor.testing.*
 import org.junit.*
 import kotlin.test.*
 

--- a/ktor-core/test/org/jetbrains/ktor/tests/routing/RoutingBuildTest.kt
+++ b/ktor-core/test/org/jetbrains/ktor/tests/routing/RoutingBuildTest.kt
@@ -1,7 +1,7 @@
 package org.jetbrains.ktor.tests.routing
 
 import org.jetbrains.ktor.routing.*
-import org.jetbrains.ktor.tests.*
+import org.jetbrains.ktor.testing.*
 import org.junit.*
 import kotlin.test.*
 

--- a/ktor-core/test/org/jetbrains/ktor/tests/routing/RoutingProcessingTest.kt
+++ b/ktor-core/test/org/jetbrains/ktor/tests/routing/RoutingProcessingTest.kt
@@ -3,7 +3,7 @@ package org.jetbrains.ktor.tests.routing
 import org.jetbrains.ktor.application.*
 import org.jetbrains.ktor.http.*
 import org.jetbrains.ktor.routing.*
-import org.jetbrains.ktor.tests.*
+import org.jetbrains.ktor.testing.*
 import org.junit.*
 import kotlin.test.*
 

--- a/ktor-core/test/org/jetbrains/ktor/tests/routing/RoutingResolveTest.kt
+++ b/ktor-core/test/org/jetbrains/ktor/tests/routing/RoutingResolveTest.kt
@@ -1,7 +1,7 @@
 package org.jetbrains.ktor.tests.routing
 
 import org.jetbrains.ktor.routing.*
-import org.jetbrains.ktor.tests.*
+import org.jetbrains.ktor.testing.*
 import org.jetbrains.ktor.util.*
 import org.junit.*
 import kotlin.test.*

--- a/ktor-jackson/pom.xml
+++ b/ktor-jackson/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>ktor</artifactId>
+        <groupId>org.jetbrains</groupId>
+        <version>0.1.4-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>ktor-jackson</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-kotlin</artifactId>
+            <version>2.6.3-4</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>ktor-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <sourceDirectory>src</sourceDirectory>
+        <testSourceDirectory>test</testSourceDirectory>
+
+        <plugins>
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/ktor-jackson/src/JacksonSupport.kt
+++ b/ktor-jackson/src/JacksonSupport.kt
@@ -1,0 +1,61 @@
+package org.jetbrains.ktor.jackson
+
+import com.fasterxml.jackson.databind.*
+import com.fasterxml.jackson.module.kotlin.*
+import org.jetbrains.ktor.application.*
+import org.jetbrains.ktor.http.*
+import org.jetbrains.ktor.routing.*
+import java.io.*
+import kotlin.reflect.*
+
+data class JsonContent(val payload: Any?)
+class RequestJsonContent internal constructor(private val mapper: ObjectMapper, private val stream: () -> InputStream) {
+    fun <T : Any> get(kClass: KClass<T>): T? = mapper.readValue(stream(), kClass.java)
+    inline fun <reified T : Any> get(): T? = get(T::class)
+}
+
+fun Application.setupJackson() {
+    setupJackson { this }
+}
+
+fun Application.setupJackson(mapperConfigure: ObjectMapper.() -> ObjectMapper) {
+    intercept(jacksonInterceptor(ObjectMapper().registerKotlinModule().mapperConfigure()))
+}
+
+fun RoutingEntry.setupJackson() {
+    setupJackson { this }
+}
+
+fun RoutingEntry.setupJackson(mapperConfigure: ObjectMapper.() -> ObjectMapper) {
+    intercept(jacksonInterceptor(ObjectMapper().registerKotlinModule().mapperConfigure()))
+}
+
+inline fun <reified T : Any> ApplicationRequest.withJsonContent(block: (T?) -> ApplicationRequestStatus): ApplicationRequestStatus =
+        content.get<RequestJsonContent>().get<T>().let { block(it) }
+
+inline fun <reified T : Any> ApplicationRequestContext.withJsonContent(block: (T?) -> ApplicationRequestStatus) : ApplicationRequestStatus =
+    request.withJsonContent(block)
+
+private fun <C : ApplicationRequestContext> jacksonInterceptor(mapper: ObjectMapper): C.(C.() -> ApplicationRequestStatus) -> ApplicationRequestStatus = { next ->
+    response.interceptSend { message, next ->
+        if (message is JsonContent) {
+            response.contentType(ContentType.Application.Json)
+            response.stream {
+                mapper.writeValue(this, message.payload)
+            }
+            ApplicationRequestStatus.Handled
+        } else {
+            next(message)
+        }
+    }
+    request.content.intercept { kClass, next ->
+        when (kClass) {
+            JsonContent::class -> JsonContent(mapper.readValue(request.content.get<InputStream>(), Any::class.java))
+            RequestJsonContent::class -> RequestJsonContent(mapper) { request.content.get<InputStream>() }
+            else -> next(kClass)
+        }
+    }
+
+    next()
+}
+

--- a/ktor-jackson/test/JacksonSupportTest.kt
+++ b/ktor-jackson/test/JacksonSupportTest.kt
@@ -1,0 +1,214 @@
+package org.jetbrains.ktor.tests
+
+import org.jetbrains.ktor.application.*
+import org.jetbrains.ktor.http.*
+import org.jetbrains.ktor.jackson.*
+import org.jetbrains.ktor.routing.*
+import org.jetbrains.ktor.testing.*
+import org.junit.*
+import kotlin.test.*
+
+class JacksonSupportTest {
+    @Test
+    fun testGetDirectUntyped() {
+        withTestApplication {
+            application.setupJackson()
+
+            application.routing {
+                get("/m") {
+                    assertEquals(mapOf("title" to "test"), request.content.get<JsonContent>().payload)
+                    ApplicationRequestStatus.Handled
+                }
+            }
+
+            val result = handleRequest(HttpMethod.Get, "/m") {
+                body = "{\"title\":\"test\"}"
+            }
+
+            assertEquals(ApplicationRequestStatus.Handled, result.requestResult)
+        }
+    }
+
+    @Test
+    fun testGetDirectTyped() {
+        withTestApplication {
+            application.setupJackson()
+
+            application.routing {
+                get("/m") {
+                    assertEquals(Model("test"), request.content.get<RequestJsonContent>().get<Model>())
+                    ApplicationRequestStatus.Handled
+                }
+            }
+
+            val result = handleRequest(HttpMethod.Get, "/m") {
+                body = "{\"title\":\"test\"}"
+            }
+
+            assertEquals(ApplicationRequestStatus.Handled, result.requestResult)
+        }
+    }
+
+    @Test
+    fun testGetWithJson() {
+        withTestApplication {
+            application.setupJackson()
+
+            application.routing {
+                get("/m") {
+                    withJsonContent<Model> {
+                        assertEquals(Model("test"), it)
+                        ApplicationRequestStatus.Handled
+                    }
+                }
+            }
+
+            val result = handleRequest(HttpMethod.Get, "/m") {
+                body = "{\"title\":\"test\"}"
+            }
+
+            assertEquals(ApplicationRequestStatus.Handled, result.requestResult)
+        }
+    }
+
+    @Test
+    fun testGetNullUntyped() {
+        withTestApplication {
+            application.setupJackson()
+
+            application.routing {
+                get("/m") {
+                    assertNull(request.content.get<JsonContent>().payload)
+                    ApplicationRequestStatus.Handled
+                }
+            }
+
+            val result = handleRequest(HttpMethod.Get, "/m") {
+                body = "null"
+            }
+
+            assertEquals(ApplicationRequestStatus.Handled, result.requestResult)
+        }
+    }
+
+    @Test
+    fun testGetNullTyped() {
+        withTestApplication {
+            application.setupJackson()
+
+            application.routing {
+                get("/m") {
+                    assertNull(request.content.get<RequestJsonContent>().get<Model>())
+                    ApplicationRequestStatus.Handled
+                }
+            }
+
+            val result = handleRequest(HttpMethod.Get, "/m") {
+                body = "null"
+            }
+
+            assertEquals(ApplicationRequestStatus.Handled, result.requestResult)
+        }
+    }
+
+    @Test
+    fun testGetWithNullTyped() {
+        withTestApplication {
+            application.setupJackson()
+
+            application.routing {
+                get("/m") {
+                    withJsonContent<Model> {
+                        assertNull(it)
+                        ApplicationRequestStatus.Handled
+                    }
+                }
+            }
+
+            val result = handleRequest(HttpMethod.Get, "/m") {
+                body = "null"
+            }
+
+            assertEquals(ApplicationRequestStatus.Handled, result.requestResult)
+        }
+    }
+
+    @Test
+    fun testSendModel() {
+        withTestApplication {
+            application.setupJackson()
+
+            application.routing {
+                get("/m") {
+                    response.send(JsonContent(Model("response")))
+                }
+            }
+
+            val result = handleRequest(HttpMethod.Get, "/m") {
+            }
+
+            assertEquals(ApplicationRequestStatus.Handled, result.requestResult)
+            assertEquals(ContentType.Application.Json, ContentType.parse(result.response.headers[HttpHeaders.ContentType]!!))
+            assertEquals("{\"title\":\"response\"}", result.response.content)
+        }
+    }
+
+    @Test
+    fun testSendModelNull() {
+        withTestApplication {
+            application.setupJackson()
+
+            application.routing {
+                get("/m") {
+                    response.send(JsonContent(null))
+                }
+            }
+
+            val result = handleRequest(HttpMethod.Get, "/m") {
+            }
+
+            assertEquals(ApplicationRequestStatus.Handled, result.requestResult)
+            assertEquals(ContentType.Application.Json, ContentType.parse(result.response.headers[HttpHeaders.ContentType]!!))
+            assertEquals("null", result.response.content)
+        }
+    }
+
+    @Test
+    fun testRoutingEntry() {
+        withTestApplication {
+            application.routing {
+                route("/api") {
+                    setupJackson()
+
+                    get("echo") {
+                        response.send(JsonContent(request.content.get<JsonContent>().payload))
+                    }
+                }
+
+                get("/") {
+                    assertFails {
+                        val value = request.content.get<JsonContent>()
+                        println(value)
+                    }
+                    ApplicationRequestStatus.Handled
+                }
+            }
+
+            val content = "{\"f\":1}"
+            val result = handleRequest(HttpMethod.Get, "/") {
+                body = content
+            }
+            assertEquals(ApplicationRequestStatus.Handled, result.requestResult)
+
+            val result2 = handleRequest(HttpMethod.Get, "/api/echo") {
+                body = content
+            }
+
+            assertEquals(ApplicationRequestStatus.Handled, result2.requestResult)
+            assertEquals(ContentType.Application.Json, ContentType.parse(result2.response.headers[HttpHeaders.ContentType]!!))
+            assertEquals(content, result2.response.content)
+        }
+    }
+}
+
+data class Model(val title: String)

--- a/ktor-samples/ktor-samples-json/pom.xml
+++ b/ktor-samples/ktor-samples-json/pom.xml
@@ -24,6 +24,11 @@
             <artifactId>gson</artifactId>
             <version>2.3.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>ktor-jackson</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
     <repositories>
         <repository>

--- a/ktor-samples/ktor-samples-json/src/org/jetbrains/ktor/samples/json/JacksonApplication.kt
+++ b/ktor-samples/ktor-samples-json/src/org/jetbrains/ktor/samples/json/JacksonApplication.kt
@@ -1,0 +1,32 @@
+package org.jetbrains.ktor.samples.json
+
+import org.jetbrains.ktor.application.*
+import org.jetbrains.ktor.jackson.*
+import org.jetbrains.ktor.locations.*
+import org.jetbrains.ktor.routing.*
+
+class JacksonApplication(config: ApplicationConfig) : Application(config) {
+    var currentModel = Model("empty", emptyList())
+
+    init {
+        setupJackson()
+
+        locations {
+            get("/model") {
+                response.send(JsonContent(currentModel))
+            }
+            get("/model/item/{key}") {
+                response.send(JsonContent(currentModel.items.first { it.key == parameters["key"] }))
+            }
+            put("/model") {
+                withJsonContent<Model> { model ->
+                    if (model != null) {
+                        currentModel = model
+                    }
+
+                    response.send(JsonContent(currentModel))
+                }
+            }
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
         <module>ktor-servlet</module>
         <module>ktor-jetty</module>
         <module>ktor-netty</module>
+        <module>ktor-jackson</module>
     </modules>
 
     <profiles>


### PR DESCRIPTION
Jackson serializer/deserializer interceptor
- per application / per routing entry configuration
- send objects through `response.send()`
- get objects through `request.content.get`
- nulls support

open questions:
- `RequestJsonContent` vs `TypedJsonContent`
- is there way to not add send and request.content interceptors for every request?
