### PR TITLE
Bind pool number and thread counter instead of globally for DefaultEx…

### DIFF
--- a/ktor-core/src/org/jetbrains/ktor/application/ApplicationEnvironment.kt
+++ b/ktor-core/src/org/jetbrains/ktor/application/ApplicationEnvironment.kt
@@ -62,9 +62,10 @@ class ApplicationEnvironmentBuilder : ApplicationEnvironment {
 }
 
 private val poolCounter = AtomicInteger()
-private val threadCounter = AtomicInteger()
 internal val DefaultExecutorServiceBuilder = {
+    val pool: Int = poolCounter.incrementAndGet()
+    val threadCounter = AtomicInteger()
     Executors.newScheduledThreadPool(Runtime.getRuntime().availableProcessors(), { r ->
-        Thread(r, "ktor-pool-${poolCounter.incrementAndGet()}-thread-${threadCounter.incrementAndGet()}")
-    })!!
+        Thread(r, "ktor-pool-$pool-thread-${threadCounter.incrementAndGet()}")
+    })
 }


### PR DESCRIPTION
…ecutorServiceBuilder.

Currently both counters have the same value.