### PR TITLE
Fix multiple dispatch problem with async servlet timeouts.

### DIFF
--- a/ktor-hosts/ktor-jetty/src/org/jetbrains/ktor/jetty/JettyApplicationHost.kt
+++ b/ktor-hosts/ktor-jetty/src/org/jetbrains/ktor/jetty/JettyApplicationHost.kt
@@ -138,6 +138,7 @@ class JettyApplicationHost(override val hostConfig: ApplicationHostConfig,
                 }
 
                 request.startAsync()
+                request.asyncContext.timeout = 0 // Overwrite any default non-null timeout to prevent multiple dispatches
                 baseRequest.isHandled = true
 
                 call.executeOn(application.executor, hostPipeline).whenComplete { state, t ->

--- a/ktor-hosts/ktor-jetty/test/MultipleDispatchOnTimeout.kt
+++ b/ktor-hosts/ktor-jetty/test/MultipleDispatchOnTimeout.kt
@@ -1,0 +1,60 @@
+import org.jetbrains.ktor.application.BasicApplicationEnvironment
+import org.jetbrains.ktor.application.call
+import org.jetbrains.ktor.application.install
+import org.jetbrains.ktor.application.respondWrite
+import org.jetbrains.ktor.config.MapApplicationConfig
+import org.jetbrains.ktor.host.applicationHostConfig
+import org.jetbrains.ktor.host.connector
+import org.jetbrains.ktor.jetty.embeddedJettyServer
+import org.jetbrains.ktor.logging.SLF4JApplicationLog
+import org.jetbrains.ktor.routing.Routing
+import org.jetbrains.ktor.routing.get
+import org.jetbrains.ktor.servlet.ServletApplicationRequest
+import org.junit.Test
+import java.net.URL
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.assertEquals
+
+
+class MultipleDispatchOnTimeout {
+
+    @Test
+    fun foo(){
+        val port = 44003
+        val appHostConfig = applicationHostConfig { connector { this.port = port } }
+        val appEnv = BasicApplicationEnvironment(javaClass.classLoader, SLF4JApplicationLog("KTorTest"), MapApplicationConfig())
+
+        val callCount = AtomicInteger(0)
+
+        val jetty = embeddedJettyServer(appHostConfig, appEnv) {
+            install(Routing, {
+                get("/foo") {
+                    callCount.incrementAndGet()
+                    val timeout: Long = (call.request as ServletApplicationRequest).servletRequest.asyncContext.timeout
+                    println("Timeout is: $timeout")
+                    Thread.sleep(timeout + 1000)
+                    call.respondWrite {
+                        write("A ok!")
+                    }
+                }
+            })
+        }
+        try {
+            jetty.start()
+
+            Thread.sleep(1000)
+
+            val result = URL("http://localhost:$port/foo").openConnection().inputStream.bufferedReader().readLine().let {
+                it
+            } ?: "<empty>"
+
+            println("Got result: $result" )
+
+            assertEquals(1, callCount.get())
+            assertEquals("A ok!", result)
+        } finally {
+            jetty.stop()
+        }
+    }
+
+}

--- a/ktor-hosts/ktor-jetty/test/MultipleDispatchOnTimeout.kt
+++ b/ktor-hosts/ktor-jetty/test/MultipleDispatchOnTimeout.kt
@@ -11,6 +11,7 @@ import org.jetbrains.ktor.routing.Routing
 import org.jetbrains.ktor.routing.get
 import org.jetbrains.ktor.servlet.ServletApplicationRequest
 import org.junit.Test
+import java.net.ServerSocket
 import java.net.URL
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.assertEquals
@@ -18,9 +19,16 @@ import kotlin.test.assertEquals
 
 class MultipleDispatchOnTimeout {
 
+    private fun findFreePort() = ServerSocket(0).use { it.localPort }
+
+    /**
+     * We are testing that the servlet container does not trigger an extra error dispatch for calls that timeout from
+     * the perspective of the servlet container. The fact that it does so is apparently specified here on this url:
+     * https://docs.oracle.com/javaee/6/api/javax/servlet/AsyncContext.html
+     */
     @Test
-    fun foo(){
-        val port = 44003
+    fun `calls with duration longer than default timeout do not trigger a redispatch`(){
+        val port = findFreePort()
         val appHostConfig = applicationHostConfig { connector { this.port = port } }
         val appEnv = BasicApplicationEnvironment(javaClass.classLoader, SLF4JApplicationLog("KTorTest"), MapApplicationConfig())
 
@@ -30,8 +38,8 @@ class MultipleDispatchOnTimeout {
             install(Routing, {
                 get("/foo") {
                     callCount.incrementAndGet()
-                    val timeout: Long = (call.request as ServletApplicationRequest).servletRequest.asyncContext.timeout
-                    println("Timeout is: $timeout")
+                    val timeout = Math.max((call.request as ServletApplicationRequest).servletRequest.asyncContext.timeout, 0)
+//                    println("Timeout is: $timeout")
                     Thread.sleep(timeout + 1000)
                     call.respondWrite {
                         write("A ok!")
@@ -48,7 +56,7 @@ class MultipleDispatchOnTimeout {
                 it
             } ?: "<empty>"
 
-            println("Got result: $result" )
+//            println("Got result: $result" )
 
             assertEquals(1, callCount.get())
             assertEquals("A ok!", result)


### PR DESCRIPTION
Servlet containers with async context will redispatch after a timeout. In Jettys case the default seems to be 30 secs. I think it is part of the three steps discribed here: https://docs.oracle.com/javaee/6/api/javax/servlet/AsyncContext.html

The provided testcase fails without the fix.

This might also be the cause of what we are seeing in #52 