### PR TITLE
Chat sample fix

### DIFF
--- a/ktor-samples/ktor-samples-websocket/src/org/jetbrains/ktor/samples/chat/ChatApplication.kt
+++ b/ktor-samples/ktor-samples-websocket/src/org/jetbrains/ktor/samples/chat/ChatApplication.kt
@@ -35,16 +35,16 @@ fun Application.main() {
 
             pingInterval = Duration.ofMinutes(1)
 
-            server.memberJoin(session.userId, this)
+            server.memberJoin(session.id, this)
 
             handle { frame ->
                 if (frame is Frame.Text) {
-                    receivedMessage(session.userId, frame.readText())
+                    receivedMessage(session.id, frame.readText())
                 }
             }
 
             close {
-                server.memberLeft(session.userId, this)
+                server.memberLeft(session.id, this)
             }
         }
 
@@ -55,7 +55,7 @@ fun Application.main() {
     }
 }
 
-data class Session(val userId: String)
+data class Session(val id: String)
 
 private suspend fun receivedMessage(id: String, command: String) {
     when {

--- a/ktor-samples/ktor-samples-websocket/src/org/jetbrains/ktor/samples/chat/ChatApplication.kt
+++ b/ktor-samples/ktor-samples-websocket/src/org/jetbrains/ktor/samples/chat/ChatApplication.kt
@@ -36,16 +36,16 @@ fun Application.main() {
 
             pingInterval = Duration.ofMinutes(1)
 
-            server.memberJoin(session.id, this)
+            server.memberJoin(session.userId, this)
 
             handle { frame ->
                 if (frame is Frame.Text) {
-                    receivedMessage(session.id, frame.readText())
+                    receivedMessage(session.userId, frame.readText())
                 }
             }
 
             close {
-                server.memberLeft(session.id, this)
+                server.memberLeft(session.userId, this)
             }
         }
 
@@ -56,7 +56,7 @@ fun Application.main() {
     }
 }
 
-data class Session(val id: String)
+data class Session(val userId: String)
 
 private suspend fun receivedMessage(id: String, command: String) {
     when {

--- a/ktor-samples/ktor-samples-websocket/src/org/jetbrains/ktor/samples/chat/ChatServer.kt
+++ b/ktor-samples/ktor-samples-websocket/src/org/jetbrains/ktor/samples/chat/ChatServer.kt
@@ -44,7 +44,7 @@ class ChatServer {
     }
 
     suspend fun who(sender: String) {
-        members[sender]?.send(Frame.Text(memberNames.keys.joinToString(prefix = "[server::who] ")))
+        members[sender]?.send(Frame.Text(memberNames.values.joinToString(prefix = "[server::who] ")))
     }
 
     suspend fun help(sender: String) {


### PR DESCRIPTION
Fixes two issues in the Chat (websocket) sample:

1. On startup (browser connecting), the application fails with
```
500 Internal Server Error

IllegalArgumentException: Couldn't instantiate type class org.jetbrains.ktor.samples.chat.Session for parameters [userId]
```

2. The '/who' command displays hash IDs instead of names.