### PR TITLE
ktor-freemarker: Rendering freemarker template without etag

### DIFF
--- a/ktor-features/ktor-freemarker/src/org/jetbrains/ktor/freemarker/FreeMarker.kt
+++ b/ktor-features/ktor-freemarker/src/org/jetbrains/ktor/freemarker/FreeMarker.kt
@@ -11,7 +11,7 @@ import org.jetbrains.ktor.util.*
 
 class FreeMarkerContent(val templateName: String,
                         val model: Any,
-                        val etag: String,
+                        val etag: String? = null,
                         val contentType: ContentType = ContentType.Text.Html.withCharset(Charsets.UTF_8))
 
 class FreeMarker(val config: Configuration) {
@@ -32,7 +32,7 @@ class FreeMarker(val config: Configuration) {
 
     private class FreeMarkerTemplateResource(val template: freemarker.template.Template,
                                              val model: Any,
-                                             val etag: String,
+                                             val etag: String?,
                                              override val contentType: ContentType) : FinalContent.WriteChannelContent(), Resource {
         suspend override fun writeTo(channel: WriteChannel) {
             val writer = channel.toOutputStream().bufferedWriter(contentType.charset() ?: Charsets.UTF_8)
@@ -43,7 +43,11 @@ class FreeMarker(val config: Configuration) {
         }
 
         override val versions: List<Version>
-            get() = listOf(EntityTagVersion(etag))
+            get() = if (etag != null) {
+                listOf(EntityTagVersion(etag))
+            } else {
+                emptyList()
+            }
 
         override val expires = null
         override val cacheControl = null

--- a/ktor-features/ktor-freemarker/test/org/jetbrains/ktor/tests/fm/FreeMarkerTest.kt
+++ b/ktor-features/ktor-freemarker/test/org/jetbrains/ktor/tests/fm/FreeMarkerTest.kt
@@ -67,6 +67,32 @@ class FreeMarkerTest {
         }
     }
 
+    @Test
+    fun testWithoutEtag() {
+        withTestApplication {
+            application.setUpTestTemplates()
+
+            application.routing {
+                val model = mapOf("id" to 1, "title" to "Hello, World!")
+
+                get("/") {
+                    call.respond(FreeMarkerContent("test.ftl", model))
+                }
+            }
+
+            handleRequest(HttpMethod.Get, "/").response.let { response ->
+                assertNotNull(response.content)
+                @Suppress("DEPRECATION")
+                assert(response.content!!.lines()) {
+                    shouldBe(listOf("<p>Hello, 1</p>", "<h1>Hello, World!</h1>"))
+                }
+                val contentTypeText = assertNotNull(response.headers[HttpHeaders.ContentType])
+                assertEquals(ContentType.Text.Html.withCharset(Charsets.UTF_8), ContentType.parse(contentTypeText))
+                assertEquals(null, response.headers[HttpHeaders.ETag])
+            }
+        }
+    }
+
     private fun Application.setUpTestTemplates() {
         val bax = "$"
 


### PR DESCRIPTION
In a typical use case, users don't want to generate ETag for HTML templates.