### PR TITLE
Compression: preserve HTTP status

### DIFF
--- a/ktor-core-tests/test/org/jetbrains/ktor/tests/http/CompressionTest.kt
+++ b/ktor-core-tests/test/org/jetbrains/ktor/tests/http/CompressionTest.kt
@@ -145,6 +145,25 @@ class CompressionTest {
     }
 
     @Test
+    fun testStatusCode() {
+        withTestApplication {
+            application.install(Compression)
+            application.routing {
+                get("/") {
+                    call.respond(TextContent("text to be compressed", status = HttpStatusCode.NotFound))
+                }
+            }
+
+            val result = handleRequest(HttpMethod.Get, "/") {
+                addHeader(HttpHeaders.AcceptEncoding, "*")
+            }
+            assertTrue(result.requestHandled)
+            assertEquals(HttpStatusCode.NotFound, result.response.status())
+            assertEquals("text to be compressed", result.response.byteContent!!.toString(Charsets.UTF_8))
+        }
+    }
+
+    @Test
     fun testMinSize() {
         withTestApplication {
             application.install(Compression) {


### PR DESCRIPTION
Preserve HTTP status of compressed responses by passing the original response status to the new one.
Before this changes, every CompressedResponse and CompressedWriteResponse would return a 200 Ok status because their status was never defined.

A new test case has been added to avoid regressions.