### PR TITLE
fix example adding a required paramter

### DIFF
--- a/ktor-samples/ktor-samples-ssl-http2/resources/application.conf
+++ b/ktor-samples/ktor-samples-ssl-http2/resources/application.conf
@@ -12,6 +12,7 @@ ktor {
     security {
         ssl {
             keyStore = target/temporary.jks
+            keyAlias = yourKeystore
             keyStorePassword = changeit
             privateKeyPassword = changeit
         }


### PR DESCRIPTION
without this parameter, I got:
```
Exception in thread "main" java.lang.IllegalArgumentException: Parameter specified as non-null is null: method kotlin.collections.ArraysKt___ArraysKt.toList, parameter $receiver
        at kotlin.collections.ArraysKt___ArraysKt.toList(_Arrays.kt)
        at org.jetbrains.ktor.netty.NettyChannelInitializer.<init>(NettyChannelInitializer.kt:27)
        at org.jetbrains.ktor.netty.NettyApplicationHost.<init>(NettyApplicationHost.kt:25)
        at org.jetbrains.ktor.netty.DevelopmentHost.main(CommandLine.kt:9)
```