### PR TITLE
Add support for UUIDs in session serialization

### DIFF
--- a/ktor-core-tests/test/org/jetbrains/ktor/tests/session/AutoSerializerTest.kt
+++ b/ktor-core-tests/test/org/jetbrains/ktor/tests/session/AutoSerializerTest.kt
@@ -100,7 +100,8 @@ data class AdditionalTypesSession(
         val optionalEmpty: Optional<String> = Optional.empty(),
         val optionWithContent: Optional<String> = Optional.of("a"),
         var bd: BigDecimal = BigDecimal.ZERO,
-        var bi: BigInteger = BigInteger.TEN
+        var bi: BigInteger = BigInteger.TEN,
+        var uuid : UUID = UUID.randomUUID()
 )
 
 enum class TestEnum { A, B, C }

--- a/ktor-core/src/org/jetbrains/ktor/sessions/SessionSerializerReflection.kt
+++ b/ktor-core/src/org/jetbrains/ktor/sessions/SessionSerializerReflection.kt
@@ -156,6 +156,7 @@ class SessionSerializerReflection<T : Any>(val type: KClass<T>) : SessionSeriali
                     type.javaType.toJavaClass().enumConstants.first { (it as? Enum<*>)?.name == value }
                 }
                 type.toJavaClass() == Float::class.java && value is Number -> value.toFloat()
+                type.toJavaClass() == UUID::class.java && value is String -> UUID.fromString(value)
                 else -> value
             }
 
@@ -251,6 +252,7 @@ class SessionSerializerReflection<T : Any>(val type: KClass<T>) : SessionSeriali
                 is Set<*> -> "#cs${serializeCollection(value)}"
                 is Map<*, *> -> "#m${serializeMap(value)}"
                 is Enum<*> -> "#s${value.name}"
+                is UUID -> "#s$value"
                 else -> throw IllegalArgumentException("Unsupported value type ${value::class.java.name}")
             }
 


### PR DESCRIPTION
In my current project, I want to store a `UUID` within a session object, finding that those are not supported during serialization. Instead of fiddling with `String`s, I would rather be very happy to have `UUID`s supported.

So I added support for `UUID`s to `SessionSerializerReflection`, quite along the lines the recently added support for enums.

I hope you like the change and accept it.

Thank you!