### PR TITLE
Default error (status) pages should properly show HTML page, not plaintext

### DIFF
--- a/ktor-core-tests/test/org/jetbrains/ktor/tests/http/StatusPageTest.kt
+++ b/ktor-core-tests/test/org/jetbrains/ktor/tests/http/StatusPageTest.kt
@@ -23,7 +23,9 @@ class StatusPageTest {
                 call.respond(HttpStatusCode.NotFound)
             }
             handleRequest(HttpMethod.Get, "/foo").let { call ->
+                assertEquals(HttpStatusCode.NotFound, call.response.status(), "Actual status must be kept")
                 assertEquals("<html><body>error 404</body></html>", call.response.content)
+                assertEquals(ContentType.Text.Html, call.response.contentType)
             }
         }
     }
@@ -51,15 +53,20 @@ class StatusPageTest {
             }
 
             handleRequest(HttpMethod.Get, "/").let { call ->
+                assertEquals(HttpStatusCode.OK, call.response.status())
                 assertEquals("ok", call.response.content)
             }
 
             handleRequest(HttpMethod.Get, "/missing").let { call ->
+                assertEquals(HttpStatusCode.NotFound, call.response.status())
                 assertEquals("404 ${HttpStatusCode.NotFound.description}", call.response.content)
+                assertEquals(ContentType.Text.Plain, call.response.contentType)
             }
 
             handleRequest(HttpMethod.Get, "/notFound").let { call ->
+                assertEquals(HttpStatusCode.NotFound, call.response.status())
                 assertEquals("404 ${HttpStatusCode.NotFound.description}", call.response.content)
+                assertEquals(ContentType.Text.Plain, call.response.contentType)
             }
         }
     }
@@ -85,7 +92,9 @@ class StatusPageTest {
             }
 
             handleRequest(HttpMethod.Get, "/missing").let { call ->
+                assertEquals(HttpStatusCode.NotFound, call.response.status())
                 assertEquals("404 ${HttpStatusCode.NotFound.description}", call.response.content)
+                assertEquals(ContentType.Text.Plain, call.response.contentType)
             }
         }
     }
@@ -119,6 +128,7 @@ class StatusPageTest {
             }
 
             handleRequest(HttpMethod.Get, "/").let { call ->
+                assertEquals(HttpStatusCode.NotFound, call.response.status())
                 assertEquals("404 ${HttpStatusCode.NotFound.description}", call.response.content)
             }
         }
@@ -143,10 +153,12 @@ class StatusPageTest {
             }
 
             handleRequest(HttpMethod.Get, "/iae").let { call ->
+                assertEquals(HttpStatusCode.InternalServerError, call.response.status())
                 assertEquals("IllegalArgumentException", call.response.content)
             }
 
             handleRequest(HttpMethod.Get, "/npe").let { call ->
+                assertEquals(HttpStatusCode.InternalServerError, call.response.status())
                 assertEquals("NullPointerException", call.response.content)
             }
         }
@@ -177,6 +189,7 @@ class StatusPageTest {
             }
 
             handleRequest(HttpMethod.Get, "/").let { call ->
+                assertEquals(HttpStatusCode.InternalServerError, call.response.status())
                 assertEquals("IllegalStateException", call.response.content)
             }
         }
@@ -199,6 +212,7 @@ class StatusPageTest {
             }
 
             handleRequest(HttpMethod.Get, "/").let { call ->
+                assertEquals(HttpStatusCode.InternalServerError, call.response.status())
                 assertEquals("IllegalStateException", call.response.content)
             }
         }
@@ -243,8 +257,15 @@ class StatusPageTest {
             }
 
             handleRequest(HttpMethod.Get, "/ve").let { call ->
+                assertEquals(HttpStatusCode.InternalServerError, call.response.status())
                 assertEquals("code", call.response.content)
             }
         }
     }
+
+    private val TestApplicationResponse.contentType: ContentType
+        get() =
+            ContentType.parse(
+                    headers[HttpHeaders.ContentType] ?: fail("Response content type is not set")
+            ).withoutParameters()
 }

--- a/ktor-core/src/org/jetbrains/ktor/features/StatusPages.kt
+++ b/ktor-core/src/org/jetbrains/ktor/features/StatusPages.kt
@@ -94,6 +94,7 @@ fun StatusPages.Configuration.statusFile(vararg code: HttpStatusCode, filePatter
         if (message == null) {
             call.respond(HttpStatusCode.InternalServerError)
         } else {
+            call.response.status(status) // preserve original status
             call.respond(message)
         }
         finish()

--- a/ktor-hosts/ktor-hosts-common/src/org/jetbrains/ktor/host/DefaultTransform.kt
+++ b/ktor-hosts/ktor-hosts-common/src/org/jetbrains/ktor/host/DefaultTransform.kt
@@ -19,7 +19,8 @@ fun ApplicationSendPipeline.installDefaultTransformations() {
                 ByteArrayContent(value)
             }
             is HttpStatusContent -> {
-                TextContent("<H1>${value.code}</H1><P>${value.message.escapeHTML()}</P>", ContentType.Text.Html, value.code)
+                TextContent("<H1>${value.code}</H1><P>${value.message.escapeHTML()}</P>",
+                        ContentType.Text.Html.withCharset(Charsets.UTF_8), value.code)
             }
             is HttpStatusCode -> {
                 HttpStatusCodeContent(value)

--- a/ktor-hosts/ktor-hosts-common/src/org/jetbrains/ktor/host/DefaultTransform.kt
+++ b/ktor-hosts/ktor-hosts-common/src/org/jetbrains/ktor/host/DefaultTransform.kt
@@ -19,8 +19,7 @@ fun ApplicationSendPipeline.installDefaultTransformations() {
                 ByteArrayContent(value)
             }
             is HttpStatusContent -> {
-                val contentType = call.defaultTextContentType(null)
-                TextContent("<H1>${value.code}</H1><P>${value.message.escapeHTML()}</P>", contentType, value.code)
+                TextContent("<H1>${value.code}</H1><P>${value.message.escapeHTML()}</P>", ContentType.Text.Html, value.code)
             }
             is HttpStatusCode -> {
                 HttpStatusCodeContent(value)


### PR DESCRIPTION
Default 404 page is showing html-markup as plain text. 
The response being sent is predefined and is clearly html in `ApplicationSendPipeline.installDefaultTransformations`:

- there's no need to favor any user-provided ContentType
- defaultTextContentType is `text/plain` which is not suitable for this case

To test: open any example like `Ktor :: Hello` and try to open any wrong url. 
Before commit:
```
<H1>404 Not Found</H1><P>Cannot find resource with the requested URI: /x</P>
```
After correction:

> ## 404 Not Found
> ### Cannot find resource with the requested URI: /x