### PR TITLE
Respond with Freemarker Template

### DIFF
--- a/ktor-features/ktor-freemarker/src/org/jetbrains/ktor/freemarker/RespondTemplate.kt
+++ b/ktor-features/ktor-freemarker/src/org/jetbrains/ktor/freemarker/RespondTemplate.kt
@@ -1,0 +1,9 @@
+package org.jetbrains.ktor.freemarker
+
+import org.jetbrains.ktor.application.ApplicationCall
+import org.jetbrains.ktor.http.ContentType
+import org.jetbrains.ktor.http.withCharset
+import org.jetbrains.ktor.response.respond
+
+suspend fun ApplicationCall.respondTemplate(templateName: String, model: Any = emptyMap<String, Any>(), etag: String? = null, contentType: ContentType = ContentType.Text.Html.withCharset(Charsets.UTF_8)) 
+    = respond(FreeMarkerContent(templateName, model, etag, contentType))

--- a/ktor-features/ktor-freemarker/src/org/jetbrains/ktor/freemarker/RespondTemplate.kt
+++ b/ktor-features/ktor-freemarker/src/org/jetbrains/ktor/freemarker/RespondTemplate.kt
@@ -1,9 +1,8 @@
 package org.jetbrains.ktor.freemarker
 
-import org.jetbrains.ktor.application.ApplicationCall
-import org.jetbrains.ktor.http.ContentType
-import org.jetbrains.ktor.http.withCharset
-import org.jetbrains.ktor.response.respond
+import org.jetbrains.ktor.application.*
+import org.jetbrains.ktor.http.*
+import org.jetbrains.ktor.response.*
 
 suspend fun ApplicationCall.respondTemplate(templateName: String, model: Any = emptyMap<String, Any>(), etag: String? = null, contentType: ContentType = ContentType.Text.Html.withCharset(Charsets.UTF_8)) 
     = respond(FreeMarkerContent(templateName, model, etag, contentType))

--- a/ktor-features/ktor-freemarker/test/org/jetbrains/ktor/tests/fm/FreeMarkerTest.kt
+++ b/ktor-features/ktor-freemarker/test/org/jetbrains/ktor/tests/fm/FreeMarkerTest.kt
@@ -94,6 +94,32 @@ class FreeMarkerTest {
         }
     }
 
+    @Test
+    fun canRespondAppropriately() {
+        withTestApplication {
+            application.setUpTestTemplates()
+
+            application.routing {
+                val model = mapOf("id" to 1, "title" to "Bonjour le monde!")
+
+                get("/") {
+                    call.respondTemplate("test.ftl", model)
+                }
+            }
+            
+            val call = handleRequest(HttpMethod.Get, "/")
+            
+            with(call.response) {
+                assertNotNull(content)
+                
+                val lines = content!!.lines()
+                
+                assertEquals(lines[0], "<p>Hello, 1</p>")
+                assertEquals(lines[1], "<h1>Bonjour le monde!</h1>")
+            }
+        }
+    }
+
     private fun Application.setUpTestTemplates() {
         val bax = "$"
 


### PR DESCRIPTION
This PR adds an extension method to the `ApplicationCall` interface which provides a quick and easy way to respond to a request with a Freemarker template.